### PR TITLE
dgoss SELinux compat - added volume mount flag

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -36,7 +36,7 @@ run(){
     case "$GOSS_FILES_STRATEGY" in
       mount)
         info "Starting docker container"
-        id=$(docker run -d -v "$tmp_dir:/goss" "${@:2}")
+        id=$(docker run -d -v "$tmp_dir:/goss:z" "${@:2}")
         docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
         ;;
       cp)


### PR DESCRIPTION
Labeling systems like SELinux require that proper labels are placed on volume content mounted into a container. Without this label, SELinux prevents `goss` from running inside a container.

Docker can apply the proper labels to a mounted volume, when the `:z` mount flag is applied.

This fixes issue #353